### PR TITLE
V0.2.0

### DIFF
--- a/lib/resque_spec/resque_spec.rb
+++ b/lib/resque_spec/resque_spec.rb
@@ -14,6 +14,7 @@ module ResqueSpec
   def queue_name(klass)
     queue_name = klass.instance_variable_get(:@queue) || klass.respond_to?(:queue) && klass.queue
     raise ::Resque::NoQueueError.new("Jobs must be placed onto a queue.") unless queue_name
+    queue_name
   end
 
   def queues


### PR DESCRIPTION
queue_name returned nil or raised an exception, but never returned the queue name. 
