### PR TITLE
Fix for @queue mutation bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resque_spec (0.3.1)
+    resque_spec (0.4.0)
       resque (>= 1.6.0)
       rspec (>= 2.0.0.beta.12)
 

--- a/lib/resque_spec/resque_scheduler_spec.rb
+++ b/lib/resque_spec/resque_scheduler_spec.rb
@@ -11,7 +11,7 @@ module ResqueSpec
   end
 
   def schedule_for(klass)
-    name = queue_name(klass).to_s << "_scheduled"
+    name = "#{queue_name(klass)}_scheduled"
     queues[name]
   end
 

--- a/spec/resque_scheduler_spec_spec.rb
+++ b/spec/resque_scheduler_spec_spec.rb
@@ -58,6 +58,11 @@ describe "ResqueSchedulerSpec" do
       ResqueSpec.schedule_for(Person) << 'queued'
       ResqueSpec.schedule_for(Person).should_not be_empty
     end
+
+    it "does not mutate the Book's @queue if it is a string" do
+      ResqueSpec.schedule_for(Book)
+      Book.instance_variable_get(:@queue).should == 'book'
+    end
   end
 
   describe "Resque" do

--- a/spec/support/book.rb
+++ b/spec/support/book.rb
@@ -1,0 +1,3 @@
+class Book
+  @queue = 'book'
+end


### PR DESCRIPTION
If the @queue is a string instead of a symbol ResqueSpec#schedule_for mutates the string because of the '<<' append method. This fix prevents that.
