### PR TITLE
#36

### DIFF
--- a/lib/resque_spec.rb
+++ b/lib/resque_spec.rb
@@ -87,13 +87,15 @@ module ResqueSpec
   end
 
   def store(queue_name, payload)
+    encoded_args = MultiJson.encode payload[:args]
+    payload[:args] = encoded_args
     queue_by_name(queue_name) << payload
   end
 
   def payload_with_string_keys(payload)
     {
       'class' => payload[:class],
-      'args' => payload[:args]
+      'args' => MultiJson.decode(payload[:args])
     }
   end
 end


### PR DESCRIPTION
Please consider this request as starting point.
What I find usefull is that ResqueSpec should mimic more than possible the production environment. While I can test what I have enqueued:

```
Model.should have_queued(instance.id)
```

resque spec does not store data as redis would do. Any data is encoded in JSON when Resque uses Redis so I guess Resque Spec should to the same.
This change would resolve the case posted in issue #36.
Please note that this change also breaks many tests. 
