### PR TITLE
have_schedule_size_of matcher

### DIFF
--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -100,3 +100,21 @@ RSpec::Matchers.define :have_scheduled_at do |*expected_args|
     "have scheduled at the given time the arguments"
   end
 end
+
+RSpec::Matchers.define :have_schedule_size_of do |size|
+  match do |actual|
+    ResqueSpec.schedule_for(actual).size == size
+  end
+
+  failure_message_for_should do |actual|
+    "expected that #{actual} would have #{size} scheduled entries, but got #{ResqueSpec.schedule_for(actual).size} instead"
+  end
+
+  failure_message_for_should_not do |actual|
+    "expected that #{actual} would have #{size} scheduled entries."
+  end
+
+  description do
+    "have schedule size of #{size}"
+  end
+end

--- a/spec/resque_spec/matchers_spec.rb
+++ b/spec/resque_spec/matchers_spec.rb
@@ -152,4 +152,24 @@ describe "ResqueSpec Matchers" do
       Person.should_not have_scheduled(last_name, first_name)
     end
   end
+  
+  describe "#have_schedule_size_of" do
+    before do
+      Resque.enqueue_at(Time.now + 5 * 60, Person, first_name, last_name)
+    end
+
+    it "raises the approrpiate exception" do
+      lambda {
+        Person.should have_schedule_size_of(2)
+      }.should raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end
+
+    it "returns true if actual schedule size matches positive expectation" do
+      Person.should have_schedule_size_of(1)
+    end
+    
+    it "returns true if actual schedule size matches negative expectation" do
+      Person.should_not have_schedule_size_of(2)
+    end
+  end
 end


### PR DESCRIPTION
Sometimes, especially when you are performing some non-trivial dynamic scheduling its handy to know the exact number of delayed jobs.
