### PR TITLE
Arguments to Job#perform should be the 'encoded'/'decoded' version.

### DIFF
--- a/lib/resque_spec.rb
+++ b/lib/resque_spec.rb
@@ -3,6 +3,7 @@ require 'resque_spec/helpers'
 require 'resque_spec/matchers'
 
 module ResqueSpec
+  include Resque::Helpers
   extend self
 
   attr_accessor :inline
@@ -93,7 +94,7 @@ module ResqueSpec
   def payload_with_string_keys(payload)
     {
       'class' => payload[:class],
-      'args' => payload[:args],
+      'args' => decode(encode(payload[:args])),
       'stored_at' => payload[:stored_at]
     }
   end

--- a/spec/resque_spec_spec.rb
+++ b/spec/resque_spec_spec.rb
@@ -211,6 +211,19 @@ describe ResqueSpec do
         ResqueSpec.queue_by_name(:queue_name).map {|h| h[:args] }.flatten.should_not include(0)
       end
     end
+
+    context "when the args contain a hash with symbol keys" do
+      before {
+        ResqueSpec.enqueue(:queue_name,
+                           NameFromClassMethod,
+                           { :key1 => '1', 'key2' => 2 })
+      }
+
+      it "deserializes the args" do
+        job = subject
+        job.args[0].should == { 'key1' => '1', 'key2' => 2 }
+      end
+    end
   end
 
   describe "#reset!" do


### PR DESCRIPTION
I discovered this when sending a hash to a job. In tests, symbols worked fine as keys in the hash, but when I fired up redis, it failed miserably.
