### PR TITLE
Fix for "have_queued" without "in" with RSpec 2.8.0

### DIFF
--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -3,6 +3,7 @@ require 'rspec'
 module InQueueHelper
   def self.extended(klass)
     klass.instance_eval do
+      self.queue_name = nil
       chain :in do |queue_name|
         self.queue_name = queue_name
       end

--- a/spec/resque_spec/matchers_spec.rb
+++ b/spec/resque_spec/matchers_spec.rb
@@ -58,6 +58,13 @@ describe "ResqueSpec Matchers" do
         it { should have_queued(first_name, last_name).in(:people) }
         it { should_not have_queued(last_name, first_name).in(:people) }
       end
+
+      context "without #in(:places) after #in(:people)" do
+        before { should have_queued(first_name, last_name).in(:people) }
+        before { Resque.enqueue(Place) }
+
+        specify { Place.should have_queued }
+      end
     end
   end
 


### PR DESCRIPTION
Resetting queue_name in the matchers to avoid matching against the previous queue name when a subsequent "have_queued" is used without a chained "in" with RSpec 2.8.0 (works fine as is in RSpec 2.7.0)
