### PR TITLE
reverse arguments' comparison order to enable usage of 'anything' matcher

### DIFF
--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -28,7 +28,7 @@ RSpec::Matchers.define :have_queued do |*expected_args|
   extend InQueueHelper
 
   match do |actual|
-    queue(actual).any? { |entry| entry[:class].to_s == actual.to_s && entry[:args] == expected_args }
+    queue(actual).any? { |entry| entry[:class].to_s == actual.to_s && expected_args == entry[:args] }
   end
 
   failure_message_for_should do |actual|
@@ -80,7 +80,7 @@ RSpec::Matchers.define :have_scheduled do |*expected_args|
   match do |actual|
     ResqueSpec.schedule_for(actual).any? do |entry|
       class_matches = entry[:class].to_s == actual.to_s
-      args_match = entry[:args] == expected_args
+      args_match = expected_args == entry[:args]
 
       time_matches = if @time
         entry[:time] == @time
@@ -113,7 +113,7 @@ RSpec::Matchers.define :have_scheduled_at do |*expected_args|
   match do |actual|
     time = expected_args.first
     other_args = expected_args[1..-1]
-    ResqueSpec.schedule_for(actual).any? { |entry| entry[:class].to_s == actual.to_s && entry[:time] == time && entry[:args] == other_args }
+    ResqueSpec.schedule_for(actual).any? { |entry| entry[:class].to_s == actual.to_s && entry[:time] == time && other_args == entry[:args] }
   end
 
   failure_message_for_should do |actual|

--- a/spec/resque_spec/matchers_spec.rb
+++ b/spec/resque_spec/matchers_spec.rb
@@ -38,6 +38,16 @@ describe "ResqueSpec Matchers" do
         it { should have_queued(first_name, last_name) }
         it { should_not have_queued(last_name, first_name) }
       end
+
+      context "with anything matcher" do
+        subject { "Person" }
+
+        it { should have_queued(anything, anything) }
+        it { should have_queued(anything, last_name) }
+        it { should have_queued(first_name, anything) }
+        it { should_not have_queued(anything) }
+        it { should_not have_queued(anything, anything, anything) }
+      end
     end
 
     context "#in" do
@@ -66,6 +76,7 @@ describe "ResqueSpec Matchers" do
         specify { Place.should have_queued }
       end
     end
+
   end
 
   describe "#have_queue_size_of" do
@@ -141,6 +152,12 @@ describe "ResqueSpec Matchers" do
       Person.should have_scheduled_at(scheduled_at, first_name, last_name)
     end
 
+    it "returns true if the arguments are found in the queue with anything matcher" do
+      Person.should have_scheduled_at(scheduled_at, anything, anything)
+      Person.should have_scheduled_at(scheduled_at, anything, last_name)
+      Person.should have_scheduled_at(scheduled_at, first_name, anything)
+    end
+
     it "returns false if the arguments are not found in the queue" do
       Person.should_not have_scheduled_at(scheduled_at, last_name, first_name)
     end
@@ -155,6 +172,12 @@ describe "ResqueSpec Matchers" do
 
     it "returns true if the arguments are found in the queue" do
       Person.should have_scheduled(first_name, last_name)
+    end
+
+    it "returns true if arguments are found in the queue with anything matcher" do
+      Person.should have_scheduled(anything, anything).at(scheduled_at)
+      Person.should have_scheduled(anything, last_name).at(scheduled_at)
+      Person.should have_scheduled(first_name, anything).at(scheduled_at)
     end
 
     it "returns false if the arguments are not found in the queue" do


### PR DESCRIPTION
Hi!

I've changed arguments' comparison order in 3 methods (have_queued, have_scheduled and have_scheduled_at) to enable usage of RSpec::Mocks::ArgumentMatchers::AnyArgMatcher. I also added tests for this. I think this can be used when not all arguments of enqueued request are important or easy to predict. I hope you will find this functionality useful.

Regards
Mateusz Konikowski
