### PR TITLE
Ability to disable the Resque monkeypatches, in order to use the default behavior of Resque in specific tests that require it.

### DIFF
--- a/lib/resque_spec.rb
+++ b/lib/resque_spec.rb
@@ -7,6 +7,7 @@ module ResqueSpec
   extend self
 
   attr_accessor :inline
+  attr_accessor :disable_ext
 
   def dequeue(queue_name, klass, *args)
     queue_by_name(queue_name).delete_if do |job|

--- a/lib/resque_spec/helpers.rb
+++ b/lib/resque_spec/helpers.rb
@@ -9,5 +9,15 @@ module ResqueSpec
         ResqueSpec.inline = false
       end
     end
+
+    def without_resque_spec
+      begin
+        ResqueSpec.disable_ext = true
+        yield
+      ensure
+        ResqueSpec.disable_ext = false
+      end
+    end
+
   end
 end

--- a/spec/resque_spec/ext_spec.rb
+++ b/spec/resque_spec/ext_spec.rb
@@ -271,4 +271,47 @@ describe "Resque Extensions" do
       end
     end
   end
+
+  context "when disable_ext is set to get the default behavior of Resque" do
+    around { |example| without_resque_spec { example.run } }
+
+    describe "Resque" do
+      describe ".enqueue" do
+        it "calls the original Resque.enqueue method" do
+          Resque.should_receive(:enqueue_without_resque_spec).with(Person, first_name, last_name)
+          Resque.enqueue(Person, first_name, last_name)
+        end
+      end
+
+      describe ".enqueue_to" do
+        it "calls the original Resque.enqueue_to method" do
+          Resque.should_receive(:enqueue_to_without_resque_spec).with(:specified, Person, first_name, last_name)
+          Resque.enqueue_to(:specified, Person, first_name, last_name)
+        end
+      end
+
+      describe ".reserve" do
+        it "calls the original Resque.reserve method" do
+          Resque.should_receive(:reserve_without_resque_spec).with(Person.queue)
+          Resque.reserve(Person.queue)
+        end
+      end
+    end
+
+    describe "Resque::Job" do
+      describe ".create" do
+        it "calls the original Resque::Job.create method" do
+          Resque::Job.should_receive(:create_without_resque_spec).with(:people, Person, first_name, last_name)
+          Resque::Job.create(:people, Person, first_name, last_name)
+        end
+      end
+
+      describe ".destroy" do
+        it "calls the original Resque::Job.destroy method" do
+          Resque::Job.should_receive(:destroy_without_resque_spec).with(:people, Person, first_name, last_name)
+          Resque::Job.destroy(:people, Person, first_name, last_name)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hey Les,

It may not be a very common use case, but I needed this for a project of mine. I think it's worth including it into mainstream or at least alias the original Resque methods so that they're not completely scratched.

Cheers,

Mathieu
