### PR TITLE
Add ResqueSpec#peek method

### DIFF
--- a/lib/resque_spec.rb
+++ b/lib/resque_spec.rb
@@ -43,6 +43,10 @@ module ResqueSpec
     queue_by_name(queue_name(klass))
   end
 
+  def peek(queue_name, start = 0, count = 1)
+    queue_by_name(queue_name).slice(start, count)
+  end
+
   def queue_name(klass)
     if klass.is_a?(String)
       klass = Kernel.const_get(klass) rescue nil


### PR DESCRIPTION
This mimicks [`Resque#peek`](http://rubydoc.info/github/defunkt/resque/Resque#peek-instance_method) by using the existing `queue_by_name` (see #51).

Note that the spec suite contains two pre-existing failures.
