### PR TITLE
Changed remove_delayed to return number of removed items to match resque...

### DIFF
--- a/lib/resque_spec/scheduler.rb
+++ b/lib/resque_spec/scheduler.rb
@@ -43,9 +43,13 @@ module ResqueSpec
   end
 
   def remove_delayed(klass, *args)
-    queue_by_name(schedule_queue_name(klass)).delete_if do |job|
+    sched_queue = queue_by_name(schedule_queue_name(klass))
+    count_before_remove = sched_queue.length
+    sched_queue.delete_if do |job|
       job[:class] == klass.to_s && job[:args] == args
     end
+    # Return number of removed items to match Resque Scheduler behaviour
+    count_before_remove - sched_queue.length
   end
 
   def schedule_for(klass)

--- a/spec/resque_spec/scheduler_spec.rb
+++ b/spec/resque_spec/scheduler_spec.rb
@@ -110,6 +110,10 @@ describe ResqueSpec do
           Resque.remove_delayed(NameFromClassMethod, 1)
           ResqueSpec.schedule_for(NameFromClassMethod).should be_empty
         end
+
+        it "should return the number of removed items" do
+          Resque.remove_delayed(NameFromClassMethod, 1).should == 1
+        end
       end
 
       describe "with #enqueue_in" do
@@ -125,6 +129,10 @@ describe ResqueSpec do
         it "should remove a scheduled item from the queue" do
           Resque.remove_delayed(NameFromClassMethod, 1)
           ResqueSpec.schedule_for(NameFromClassMethod).should be_empty
+        end
+
+        it "should return the number of removed items" do
+          Resque.remove_delayed(NameFromClassMethod, 1).should == 1
         end
       end
 


### PR DESCRIPTION
..._scheduler behaviour.

Currently, ResqueSpec::remove_delayed returns the remaining items in the scheduler queue after the requested removal has been processed. ResqueScheduler, however, returns the number of items removed from the queue. This change brings ResqueSpec's mock behaviour inline with that of ResqueScheduler. 

Based on ResqueScheduler version 2.0.0
