### PR TITLE
Implement Resque#peek publicly

### DIFF
--- a/lib/resque_spec/ext.rb
+++ b/lib/resque_spec/ext.rb
@@ -32,6 +32,7 @@ module Resque
   alias :enqueue_without_resque_spec :enqueue
   alias :enqueue_to_without_resque_spec :enqueue_to if Resque.respond_to? :enqueue_to
   alias :reserve_without_resque_spec :reserve
+  alias :peek_without_resque_spec :peek
 
   def enqueue(klass, *args)
     return enqueue_without_resque_spec(klass, *args) if ResqueSpec.disable_ext
@@ -51,6 +52,13 @@ module Resque
       Job.create(queue, klass, *args)
       run_after_enqueue(klass, *args)
       true
+    end
+  end
+
+  def peek(queue, start = 0, count = 1)
+    return peek_without_resque_spec(queue, start, count) if ResqueSpec.disable_ext
+    ResqueSpec.peek(queue, start, count).map do |job|
+      job.inject({}) { |a, (k, v)| a[k.to_s] = v; a }
     end
   end
 

--- a/spec/resque_spec/ext_spec.rb
+++ b/spec/resque_spec/ext_spec.rb
@@ -25,6 +25,22 @@ describe "Resque Extensions" do
       end
     end
 
+    describe '#peek' do
+      before do
+        Resque.enqueue(Person, first_name, last_name)
+      end
+
+      it 'should return the queued task' do
+        Resque.peek(:people).should have(1).elements
+      end
+
+      it 'should return a job with string keys' do
+        job = Resque.peek(:people).first
+        job.should have_key('args')
+        job.should have_key('class')
+      end
+    end
+
     describe "#enqueue_to" do
       context "successfully queues" do
         subject do


### PR DESCRIPTION
Although `ResqueSpec#peek` was implemented in #52, `Resque#peek` was not, so
Resque's behaviour was not actually overridden.

This also exposes an issue with ResqueSpec storing jobs as hashes with
symbol keys, while Resque itself seems to yield hashes with string keys.
