### PR TITLE
Add Resque.size as a value to be mocked out by ResqueSpec

### DIFF
--- a/lib/resque_spec/ext.rb
+++ b/lib/resque_spec/ext.rb
@@ -33,6 +33,7 @@ module Resque
   alias :enqueue_to_without_resque_spec :enqueue_to if Resque.respond_to? :enqueue_to
   alias :reserve_without_resque_spec :reserve
   alias :peek_without_resque_spec :peek
+  alias :size_without_resque_spec :size
 
   def enqueue(klass, *args)
     return enqueue_without_resque_spec(klass, *args) if ResqueSpec.disable_ext
@@ -66,6 +67,12 @@ module Resque
     return reserve_without_resque_spec(queue_name) if ResqueSpec.disable_ext
 
     ResqueSpec.pop(queue_name)
+  end
+
+  def size(queue_name)
+    return size_without_resque_spec(queue_name) if ResqueSpec.disable_ext
+
+    ResqueSpec.queue_by_name(queue_name).count
   end
 
   private

--- a/spec/resque_spec/ext_spec.rb
+++ b/spec/resque_spec/ext_spec.rb
@@ -260,6 +260,17 @@ describe "Resque Extensions" do
         end
       end
     end
+
+    describe "#size" do
+      context "given a valid queue" do
+        subject { Resque.size(Person.queue) }
+        it { should eq(3) }
+      end
+      context "given an invalid queue" do
+        subject { Resque.size("not_a_queue")}
+        it { should eq(0) }
+      end
+    end
   end
 
   describe Resque::Job do


### PR DESCRIPTION
We had a situation where we needed to be able to use Resque.size, so I added it.
