### PR TITLE
Daylight-saving issue on intervals

### DIFF
--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -85,7 +85,7 @@ RSpec::Matchers.define :have_scheduled do |*expected_args|
       time_matches = if @time
         entry[:time] == @time
       elsif @interval
-        entry[:time].to_i == entry[:stored_at].to_i + @interval
+        entry[:time].to_i == (entry[:stored_at] + @interval).to_i
       else
         true
       end


### PR DESCRIPTION
I had a mysterious bug lately, when my specs weren't working for e.g. have_scheduled(....).in(10.days). This was due to the calculation of the expected scheduled_at timing and the stored_at + interval timing, They just didn't match due to the missing daylight saving hour in Europe. I bolied it down to the issue that (Time object).to_i + an integer timestamp is different to (Time object + interval).to_i .
In order to test the issue you might have to change your computer clock.
