### PR TITLE
Add times chain

### DIFF
--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -32,6 +32,11 @@ RSpec::Matchers.define :have_queued do |*expected_args|
     @times_info = @times == 1 ? ' once' : " #{@times} times"
   end
 
+  chain :once do |num_times_queued|
+    @times = 1
+    @times_info = ' once'
+  end
+
   match do |actual|
     matched = queue(actual).select do |entry|
       klass = entry.fetch(:class)

--- a/spec/resque_spec/matchers_spec.rb
+++ b/spec/resque_spec/matchers_spec.rb
@@ -78,7 +78,9 @@ describe "ResqueSpec Matchers" do
     end
 
     context "#times" do
+
       subject { Person }
+
       context "job queued once" do
         before do
           Resque.enqueue(Person, first_name, last_name)
@@ -88,9 +90,27 @@ describe "ResqueSpec Matchers" do
         it { should have_queued(first_name, last_name).times(1) }
         it { should_not have_queued(first_name, last_name).times(2) }
       end
+
       context "no job queued" do
         it { should have_queued(first_name, last_name).times(0) }
         it { should_not have_queued(first_name, last_name).times(1) }
+      end
+    end
+
+    context "#once" do
+
+      subject { Person }
+
+      context "job queued once" do
+        before do
+          Resque.enqueue(Person, first_name, last_name)
+        end
+
+        it { should have_queued(first_name, last_name).once }
+      end
+
+      context "no job queued" do
+        it { should_not have_queued(first_name, last_name).once }
       end
     end
   end


### PR DESCRIPTION
Allow assertion on number of times a job is queued.

``` ruby
  # Example:
  before do
     Resque.enqueue(Person, first_name, last_name)
  end

  it { should have_queued(first_name, last_name).once }
  it { should have_queued(first_name, last_name).times(1) }
  it { should_not have_queued(first_name, last_name).times(2) }

```
