### PR TITLE
Revert rubygems 2.0.0 requirement.

### DIFF
--- a/resque_spec.gemspec
+++ b/resque_spec.gemspec
@@ -4,7 +4,7 @@ $:.unshift lib unless $:.include?(lib)
 require "resque_spec/version"
 
 Gem::Specification.new do |s|
-  s.required_rubygems_version = '>= 2.0.0'
+  s.required_rubygems_version = '>= 1.3.6'
 
   s.name = 'resque_spec'
   s.version = ResqueSpec::VERSION


### PR DESCRIPTION
Seems it's not necessary given the facilities used in the gem, and imposes a burden on users to update.

In our case, we currently can't run our CI on tddium.

Was introduced here: 9e2a9fccef2d1a9480efebf81343a44826d10469
