### PR TITLE
added test case for when a queue is passed to 'enqueue_in_with_queue' wh...

### DIFF
--- a/lib/resque_spec/scheduler.rb
+++ b/lib/resque_spec/scheduler.rb
@@ -84,7 +84,7 @@ module ResqueSpec
   end
 
   def schedule_queue_name(klass)
-    "#{queue_name(klass)}_scheduled"
+    queue_name(klass)
   end
 end
 

--- a/spec/resque_spec/scheduler_spec.rb
+++ b/spec/resque_spec/scheduler_spec.rb
@@ -157,6 +157,11 @@ describe ResqueSpec do
       it "uses the correct queue" do
         ResqueSpec.queue_by_name(:test_queue).should_not be_empty
       end
+
+      it "uses the correct queue when the queue argument is the same defined on the worker class" do
+        Resque.enqueue_in_with_queue(:name_from_class_method, scheduled_in, NameFromClassMethod, 1)
+        ResqueSpec.schedule_for(NameFromClassMethod).should_not be_empty
+      end
     end
 
     describe "#remove_delayed" do


### PR DESCRIPTION
I developed a proxy to abstract our code base from the background-processing library, which always calls the 'enqueue_in_with_queue' method.

The problem is that sometimes the queue name, it passes, is also defined inside the worker class (with an instance variable) and our specs are written like this "ResqueSpec.schedule_for(NameFromClassMethod).should_not be_empty". This causes our tests to break because the 'schedule_queue_name' always append '_scheduled' to the queue name. Removing this works fine for me and is not breaking any other test, so I suppose it's fine, since I also did not find any reference to it the resque_scheduler gem.
