### PR TITLE
fixed compatibility for resque 2

### DIFF
--- a/lib/resque_spec.rb
+++ b/lib/resque_spec.rb
@@ -3,7 +3,6 @@ require 'resque_spec/helpers'
 require 'resque_spec/matchers'
 
 module ResqueSpec
-  include Resque::Helpers
   extend self
 
   attr_accessor :inline
@@ -102,6 +101,14 @@ module ResqueSpec
       'args' => decode(encode(payload[:args])),
       'stored_at' => payload[:stored_at]
     }
+  end
+
+  def encode(object)
+    Resque.encode(object)
+  end
+
+  def decode(object)
+    Resque.decode(object)
   end
 end
 


### PR DESCRIPTION
Fixed this deprecation warning for Resque 2:

![screen shot 2013-11-13 at 2 16 40 pm](https://f.cloud.github.com/assets/216188/1536344/4da63ef4-4cb1-11e3-8ac4-2bf6814c53fb.png)
