### PR TITLE
fixed travis link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ResqueSpec
 ==========
 
 [![Build
-Status](https://travis-ci.org/leshill/resque_spec.png)](https://travis-ci.org/leshill/resque_spec])
+Status](https://travis-ci.org/leshill/resque_spec.png)](https://travis-ci.org/leshill/resque_spec)
 
 A test double of Resque for RSpec and Cucumber. The code was originally based
 on


### PR DESCRIPTION
I accidentally added a `]` to the build link.
