### PR TITLE
Alias 'be_queued' matcher to 'have_queued'.

### DIFF
--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -66,6 +66,10 @@ RSpec::Matchers.define :have_queued do |*expected_args|
   end
 end
 
+module RSpec::Matchers
+  alias :be_queued :have_queued
+end
+
 RSpec::Matchers.define :have_queue_size_of do |size|
   extend InQueueHelper
 


### PR DESCRIPTION
One note about the alias: the description and failure messages would still reflect the "have queued" language instead of "be queued" language. This makes the spec output a little misleading.

See #84
