### PR TITLE
fix(matchers): do not include rspec-mocks since it can mess with mocha w...

### DIFF
--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -1,6 +1,5 @@
 require 'rspec/core'
 require 'rspec/expectations'
-require 'rspec/mocks'
 
 module ArgsHelper
   private


### PR DESCRIPTION
The inclusion of rspec/mocks in this file brings a bug when I'm using Mocha.

To get a better understanding of what happens  here a clear commit : https://github.com/mfo/resque_spec/commit/24bd2f08c18da1d5e191de237723b38b521bbb39

Use : $ rspec spec/resque_spec/mocking_spec.rb (makes sense only in isolation). It raises 'The use of doubles or partial doubles from rspec-mocks outside of the per-test lifecycle is not supported.' due to the inclusion of rspec-mocks from the lib/resque_spec/matchers.rb.

