### PR TITLE
Correct ArgumentListMatcher instrumentation to make it work with any_args

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,13 +11,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.0.8)
-    columnize (0.3.6)
-    debugger (1.6.5)
+    columnize (0.9.0)
+    debugger (1.6.8)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.5)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
+    debugger-ruby_core_source (1.3.8)
     diff-lcs (1.2.5)
     method_source (0.8.1)
     mono_logger (1.1.0)
@@ -82,3 +82,6 @@ DEPENDENCIES
   resque_spec!
   rspec (>= 3.0.0)
   timecop
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.0.8)
+    coderay (1.1.0)
     columnize (0.9.0)
     debugger (1.6.8)
       columnize (>= 0.3.1)
@@ -19,16 +19,16 @@ GEM
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.3.8)
     diff-lcs (1.2.5)
-    method_source (0.8.1)
+    method_source (0.8.2)
     mono_logger (1.1.0)
     multi_json (1.8.0)
-    pry (0.9.11.4)
-      coderay (~> 1.0.5)
-      method_source (~> 0.8)
+    pry (0.10.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-debugger (0.2.2)
+    pry-debugger (0.2.3)
       debugger (~> 1.3)
-      pry (~> 0.9.10)
+      pry (>= 0.9.10, < 0.11.0)
     rack (1.5.2)
     rack-protection (1.5.0)
       rack
@@ -64,7 +64,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
-    slop (3.4.3)
+    slop (3.6.0)
     tilt (1.4.1)
     timecop (0.6.3)
     tzinfo (1.0.1)
@@ -82,6 +82,3 @@ DEPENDENCIES
   resque_spec!
   rspec (>= 3.0.0)
   timecop
-
-BUNDLED WITH
-   1.10.6

--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -75,45 +75,7 @@ RSpec::Matchers.define :be_queued do |*expected_args|
 
 end
 
-RSpec::Matchers.define :have_queued do |*expected_args|
-  include InQueueHelper
-
-  chain :times do |num_times_queued|
-    @times = num_times_queued
-    @times_info = @times == 1 ? ' once' : " #{@times} times"
-  end
-
-  chain :once do
-    @times = 1
-    @times_info = ' once'
-  end
-
-  match do |actual|
-    matched = queue(actual).select do |entry|
-      klass = entry.fetch(:class)
-      args = entry.fetch(:args)
-      klass.to_s == actual.to_s && match_args(expected_args, args)
-    end
-
-    if @times
-      matched.size == @times
-    else
-      matched.size > 0
-    end
-  end
-
-  failure_message do |actual|
-    "expected that #{actual} would have [#{expected_args.join(', ')}] queued#{@times_info}"
-  end
-
-  failure_message_when_negated do |actual|
-    "expected that #{actual} would not have [#{expected_args.join(', ')}] queued#{@times_info}"
-  end
-
-  description do
-    "have queued arguments of [#{expected_args.join(', ')}]#{@times_info}"
-  end
-end
+RSpec::Matchers.alias_matcher :have_queued, :be_queued
 
 RSpec::Matchers.define :have_queue_size_of do |size|
   include InQueueHelper

--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -6,8 +6,8 @@ module ArgsHelper
   private
 
   def match_args(expected_args, args)
-    arg_list_matcher = RSpec::Mocks::ArgumentListMatcher.new(expected_args)
-    arg_list_matcher.args_match?(args)
+    arg_list_matcher = RSpec::Mocks::ArgumentListMatcher.new(*expected_args)
+    arg_list_matcher.args_match?(*args)
   end
 end
 

--- a/spec/resque_spec/matchers_spec.rb
+++ b/spec/resque_spec/matchers_spec.rb
@@ -20,6 +20,52 @@ describe "ResqueSpec Matchers" do
       it { should_not be_queued(last_name, first_name) }
     end
 
+
+    context "queued with any_args or *anything" do
+      context "for nil" do
+        before do
+          Resque.enqueue(Person)
+        end
+
+        subject { Person }
+
+        it { should be_queued(any_args) }
+      end
+
+      context "for a single parameter" do
+        before do
+          Resque.enqueue(Person, first_name)
+        end
+
+        subject { Person }
+
+        it { should be_queued(any_args) }
+      end
+
+      context "for multiple parameters" do
+        before do
+          Resque.enqueue(Person, first_name, last_name, [:foo])
+        end
+
+        subject { Person }
+
+        it { should be_queued(any_args) }
+      end
+
+      context "multiple times for any parameters" do
+        before do
+          Resque.enqueue(Person)
+          Resque.enqueue(Person, first_name)
+          Resque.enqueue(Person, first_name, [:foo])
+        end
+
+        subject { Person }
+
+        it { should be_queued(any_args) }
+        it { should be_queued(any_args).times(3) }
+      end
+    end
+
     context "queued with a string" do
       before do
         Resque::Job.create(:people, "Person", first_name, last_name)

--- a/spec/resque_spec/matchers_spec.rb
+++ b/spec/resque_spec/matchers_spec.rb
@@ -22,17 +22,31 @@ describe "ResqueSpec Matchers" do
 
 
     context "queued with any_args or *anything" do
-      context "for nil" do
+      context "for no args" do
         before do
           Resque.enqueue(Person)
         end
 
         subject { Person }
 
+        # anything does not match nothing
+        it { should_not be_queued(anything) }
+        # any_args matches no args
         it { should be_queued(any_args) }
       end
 
-      context "for a single parameter" do
+      context "for nil" do
+        before do
+          Resque.enqueue(Person, nil)
+        end
+
+        subject { Person }
+
+        it { should be_queued(anything) }
+        it { should be_queued(any_args) }
+      end
+
+      context "for a single non-nil parameter" do
         before do
           Resque.enqueue(Person, first_name)
         end
@@ -40,15 +54,17 @@ describe "ResqueSpec Matchers" do
         subject { Person }
 
         it { should be_queued(any_args) }
+        it { should be_queued(anything) }
       end
 
       context "for multiple parameters" do
         before do
-          Resque.enqueue(Person, first_name, last_name, [:foo])
+          Resque.enqueue(Person, first_name, nil, [:foo])
         end
 
         subject { Person }
 
+        it { should be_queued(anything, anything, anything).once }
         it { should be_queued(any_args) }
       end
 
@@ -56,7 +72,7 @@ describe "ResqueSpec Matchers" do
         before do
           Resque.enqueue(Person)
           Resque.enqueue(Person, first_name)
-          Resque.enqueue(Person, first_name, [:foo])
+          Resque.enqueue(Person, first_name, nil, [:foo])
         end
 
         subject { Person }


### PR DESCRIPTION
The ArgsHelper module did not instrument the ArgumentListMatcher correctly, hence it was not possible to use any_args with the be_queued/have_queued matchers.

original code:
```
module ArgsHelper
  private

  def match_args(expected_args, args)
    arg_list_matcher = RSpec::Mocks::ArgumentListMatcher.new(expected_args)
    arg_list_matcher.args_match?(args)
  end
end
```
Within the ArgumentListMatcher you did end up in the fuzzy_matcher comparing *lists of lists* instead of lists.
```
   28          expected_list.zip(actual_list).all? do |expected, actual|
   29            values_match?(expected, actual)
   30          end
```
(rspec-support-3.0.0/lib/rspec/support/fuzzy_matcher.rb:28)
So `have_queued(:foo, :bar)` ends up to be compared as expected_list == [[:foo, :bar]] instead of [:foo, :bar]
Naturally, that works as `values_match?([:foo, :bar], [:foo, :bar])`, but not intentionally. What we'd like to see was zipping and matching all?  `values_match?(:foo, :foo)` and `values_match?(:bar, :bar)`.

The Problem arises when using any_args matching vs no args, nil, :foo and multiple args 
```
Resque.enqueue(Person)
# breaks
it { should be_queued(any_args) }
```
```
Resque.enqueue(Person, nil)
# breaks
it { should be_queued(any_args) }
```
```
Resque.enqueue(Person, :foo)
# breaks
it { should be_queued(any_args) }
```


The fix is simple, desplatting before instrumenting the ArgumentListMatcher:
```
module ArgsHelper
  private

  def match_args(expected_args, args)
    arg_list_matcher = RSpec::Mocks::ArgumentListMatcher.new(*expected_args)
    arg_list_matcher.args_match?(*args)
  end
end
```

Cheers
SH