### PR TITLE
Add at_or_in matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,23 @@ describe "#recalculate" do
 end
 ```
 
+And I might use the `in` or `at` statement to specify time:
+
+```ruby
+describe "#recalculate" do
+  before do
+    ResqueSpec.reset!
+  end
+
+  it "adds person.calculate to the Person queue" do
+    person.recalculate
+
+    # Is it scheduled to be executed in 5 minutes or at 2010-02-14 06:00:00 ??
+    expect(Person).to have_scheduled(person.id, :calculate).at_or_in(Time.mktime(2010,2,14,6,0,0), 5 * 60)
+  end
+end
+```
+
 You can also check the size of the schedule:
 
 ```ruby

--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -156,12 +156,20 @@ RSpec::Matchers.define :have_scheduled do |*expected_args|
     @time_info = "in #{@interval} seconds"
   end
 
+  chain :at_or_in do |timestamp, interval|
+    @time = timestamp
+    @interval = interval
+    @time_info = "at #{@time} or in #{@interval} seconds"
+  end
+
   match do |actual|
     schedule_queue_for(actual).any? do |entry|
       class_matches = entry[:class].to_s == actual.to_s
       args_match = match_args(expected_args, entry[:args])
 
-      time_matches = if @time
+      time_matches = if @time and @interval
+        (entry[:time].to_i == @time.to_i) or (entry[:time].to_i == (entry[:stored_at] + @interval).to_i)
+      elsif @time
         entry[:time].to_i == @time.to_i
       elsif @interval
         entry[:time].to_i == (entry[:stored_at] + @interval).to_i

--- a/spec/resque_spec/matchers_spec.rb
+++ b/spec/resque_spec/matchers_spec.rb
@@ -455,6 +455,27 @@ describe "ResqueSpec Matchers" do
       end
     end
 
+    context "with #at_or_in(timestamp, interval)" do
+      let(:interval) { 10 * 60 }
+      let(:scheduled_at) { Time.now + 30 * 60 }
+
+      before(:each) do
+        if [true, false].sample
+          Resque.enqueue_in(interval, Person, first_name, last_name)
+        else
+          Resque.enqueue_at(scheduled_at, Person, first_name, last_name)
+        end
+      end
+
+      it "returns true if arguments, timestamp or interval matches positive expectation" do
+        Person.should have_scheduled(first_name, last_name).at_or_in(scheduled_at, interval)
+      end
+
+      it "returns true if arguments, timestamp, and interval matches negative expectation" do
+        Person.should_not have_scheduled(first_name, last_name).at_or_in(Time.now + 60 * 60, 100 * 60)
+      end
+    end
+
     context "with #queue(queue_name)" do
       let(:interval) { 10 * 60 }
 


### PR DESCRIPTION
I had to run some A/B testing on my project sending some emails at specific time and others at a specific interval, but then I ran into the issue of how to test this behavior on my specs, that's why I've created a new matcher `at_or_in` to test against both options either `enqueue_at` or `enqueue_in` method