### PR TITLE
Fix ResqueMailer snippet not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ describe "#welcome_email" do
 
   subject { described_class }
   it { should have_queue_size_of(1) }
-  it { should have_queued(:welcome_email, user.id) }
+  it { should have_queued(:welcome_email, [user.id]) }
 end
 ```
 


### PR DESCRIPTION
After stumbling a while testing a ResqueMailer, looked into ResqueSpec queues and saw parameters of mailers queues as `:email_method, [args]`